### PR TITLE
Bind DevilsPlayground object to reset call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Changelog
 
+### Fixed
+- Bind DevilsPlayground object to call of reset() method, so the counter resets
+  when the reset() method is called.
+
 ## [0.2.0] - 2018-09-10
 ### Added
 - Initial Release

--- a/js/devils-playground.js
+++ b/js/devils-playground.js
@@ -118,13 +118,13 @@ DevilsPlayground.prototype.addListeners = function() {
   var self = this,
     options = this.isPassiveSupported() ? { passive: true } : false;
 
-  document.addEventListener("mousemove", self.reset, options);
-  document.addEventListener("mousedown", self.reset, options);
-  document.addEventListener("keypress", self.reset, options);
-  document.addEventListener("DOMMouseScroll", self.reset, options);
-  document.addEventListener("mousewheel", self.reset, options);
-  document.addEventListener("touchmove", self.reset, options);
-  document.addEventListener("MSPointerMove", self.reset, options);
+  document.addEventListener("mousemove", self.reset.bind(this), options);
+  document.addEventListener("mousedown", self.reset.bind(this), options);
+  document.addEventListener("keypress", self.reset.bind(this), options);
+  document.addEventListener("DOMMouseScroll", self.reset.bind(this), options);
+  document.addEventListener("mousewheel", self.reset.bind(this), options);
+  document.addEventListener("touchmove", self.reset.bind(this), options);
+  document.addEventListener("MSPointerMove", self.reset.bind(this), options);
 };
 
 /**


### PR DESCRIPTION
The lexical context (value of this) was incorrect when the reset()
method was called. Inside reset() we were seeing the default lexical
context (the window object) instead of our DevilsPlayground instance.

By binding our reset() method to our DevilsPlayground instance (`this`
inside our addListeners() method) we correct this problem.

See #1