### PR TITLE
Eliminate self variable in addListeners() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Changelog
 
+### Changed
+- Eliminate unnecessary 'self' variable in addListeners() method
+
 ### Fixed
 - Bind DevilsPlayground object to call of reset() method, so the counter resets
   when the reset() method is called.

--- a/js/devils-playground.js
+++ b/js/devils-playground.js
@@ -115,16 +115,15 @@ DevilsPlayground.prototype.isSecondCounterMax = function() {
  */
 DevilsPlayground.prototype.addListeners = function() {
 
-  var self = this,
-    options = this.isPassiveSupported() ? { passive: true } : false;
+  var options = this.isPassiveSupported() ? { passive: true } : false;
 
-  document.addEventListener("mousemove", self.reset.bind(this), options);
-  document.addEventListener("mousedown", self.reset.bind(this), options);
-  document.addEventListener("keypress", self.reset.bind(this), options);
-  document.addEventListener("DOMMouseScroll", self.reset.bind(this), options);
-  document.addEventListener("mousewheel", self.reset.bind(this), options);
-  document.addEventListener("touchmove", self.reset.bind(this), options);
-  document.addEventListener("MSPointerMove", self.reset.bind(this), options);
+  document.addEventListener("mousemove", this.reset.bind(this), options);
+  document.addEventListener("mousedown", this.reset.bind(this), options);
+  document.addEventListener("keypress", this.reset.bind(this), options);
+  document.addEventListener("DOMMouseScroll", this.reset.bind(this), options);
+  document.addEventListener("mousewheel", this.reset.bind(this), options);
+  document.addEventListener("touchmove", this.reset.bind(this), options);
+  document.addEventListener("MSPointerMove", this.reset.bind(this), options);
 };
 
 /**


### PR DESCRIPTION
Assigning the lexical context (this) to a variable called 'self' is not
necessary in the addListeners() method because the value value of 'this' does
NOT change anywhere in this method.

Therefore we can simplify things by removing this extraneous variable.

See #5